### PR TITLE
adjust build options to make it compile on FreeBSD

### DIFF
--- a/HFuse.cabal
+++ b/HFuse.cabal
@@ -16,11 +16,17 @@ Library
   Build-Depends:          base >= 4 && < 5, unix, bytestring
   exposed-Modules:        System.Fuse
   Extensions:             ForeignFunctionInterface ScopedTypeVariables EmptyDataDecls
-  Includes:               sys/statfs.h, dirent.h, fuse.h, fcntl.h
+  Includes:               dirent.h, fuse.h, fcntl.h
+  if os(freebsd) {
+    Includes:             sys/param.h, sys/mount.h
+    CC-Options:           -Df_namelen=f_namemax
+  } else {
+    Includes:             sys/statfs.h
+  }
   Include-Dirs:           /usr/include, /usr/local/include, .
   Extra-Libraries:        fuse
   Extra-Lib-Dirs:         /usr/local/lib
-  CC-Options:             -D_FILE_OFFSET_BITS=64
+  CC-Options:             -D_FILE_OFFSET_BITS=64 -DFUSE_USE_VERSION=26
   if os(darwin) {
     CC-Options:           "-DMACFUSE"
   }

--- a/System/Fuse.hsc
+++ b/System/Fuse.hsc
@@ -77,9 +77,7 @@ import qualified System.IO.Error as IO(catch,ioeGetErrorString)
 -- TODO: implement binding to fuse_invalidate
 -- TODO: bind fuse_*xattr
 
-#define FUSE_USE_VERSION 26
-
-#ifdef MACFUSE
+#if defined MACFUSE || defined __FreeBSD__
 #include <sys/mount.h>
 #else
 #include <sys/statfs.h>


### PR DESCRIPTION
notes:
- a bug in FUSE causes configure to fail on FreeBSD if `FUSE_USE_VERSION` is not set, that's why i moved it to the cabal file
- the FreeBSD manpage for `fstat` says to include both `<sys/param.h>` and `<sys/mount.h>` but it also works with only the latter. i don't know if it's the same for Darwin, maybe you want to check and include `<sys/param.h>` in that case, too.
