### PR TITLE
updated cabal file to work with OSXFUSE 2.3.9

### DIFF
--- a/HFuse.cabal
+++ b/HFuse.cabal
@@ -16,8 +16,13 @@ Library
   Build-Depends:          base >= 4 && < 5, unix, bytestring
   exposed-Modules:        System.Fuse
   Extensions:             ForeignFunctionInterface ScopedTypeVariables EmptyDataDecls
-  Includes:               sys/statfs.h, dirent.h, fuse.h, fcntl.h
-  Include-Dirs:           /usr/include, /usr/local/include, .
+  if os(darwin) {
+      Includes:               dirent.h, fuse.h, fcntl.h
+      Include-Dirs:           /usr/local/include/osxfuse, /usr/include, /usr/local/include, .
+  } else {
+      Includes:               sys/statfs.h, dirent.h, fuse.h, fcntl.h
+      Include-Dirs:           /usr/include, /usr/local/include, .
+  }
   Extra-Libraries:        fuse
   Extra-Lib-Dirs:         /usr/local/lib
   CC-Options:             -D_FILE_OFFSET_BITS=64


### PR DESCRIPTION
I've slightly modified the cabal file so HFuse once again configures and builds on my OS X Lion machine, using OSXFUSE 2.3.9. Note that the file <sys/statfs.h> still poses a problem, but I've filed a bug upstream to OSXFUSE, since I believe this file doesn't need to be included on OS X (I support this claim by using the workaround `touch /usr/local/include/sys/statfs.h` to build HFuse). See the bug here: https://github.com/osxfuse/osxfuse/issues/25.

If this is all in error, I'd like to hear how I should resolve the issue nicely :)
